### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "Arpad Borsos <arpad.borsos@googlemail.com> (http://swatinem.de)"
   ],
   "dependencies": {
-    "jade": "~1.3.0",
-    "with": "~3.0.0"
+    "jade": "~1.11.0",
+    "with": "~5.0.0"
   },
   "peerDependencies": {
   },


### PR DESCRIPTION
Increment dependency versions. The versions of `jade` and `with` both seem to have issues in dependencies of these dependencies inside the browser (at least when included via jspm/SystemJS). Upgrades to these dependencies of dependencies move to `acorn` which seems to work better in browser.
